### PR TITLE
Add PORT to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN DITTO_NSEC=$(deno task nsec) && \
 RUN deno cache src/server.ts
 COPY favicon.ico .
 COPY soapbox-logo.svg .
+ENV PORT 8000
 EXPOSE 8000/tcp
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
The Ditto default port got changed to 4036.

You can set a `PORT` variable in the env to make it whatever you want. Setting it to 8000 will make it continue to work.